### PR TITLE
Support exception_notification 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3
+  - 2.4
 before_install:
   # This is a workaround for a bug in bundler that Travis' VM comes with by default
   - gem update bundler

--- a/exception_notification-rake.gemspec
+++ b/exception_notification-rake.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
     ' sending mail upon failures in Rake tasks'
 
   s.required_ruby_version = '>= 2.0'
-  s.add_runtime_dependency 'exception_notification', '~> 4.2.0'
+  s.add_runtime_dependency 'exception_notification', '~> 4.3'
   # NB: Rake before 0.9.0 won't support the exception hook we're using
   s.add_runtime_dependency 'rake', '>= 0.9.0'
 
@@ -27,11 +27,11 @@ Gem::Specification.new do |s|
   if RUBY_VERSION >= '2.2'
     # No restrictions known at this point
   elsif RUBY_VERSION >= '2.1'
-    s.add_development_dependency 'actionmailer', '~> 4.2.0'
-    s.add_development_dependency 'activesupport', '~> 4.2.0'
+    s.add_development_dependency 'actionmailer', '~> 4.2'
+    s.add_development_dependency 'activesupport', '~> 4.2'
   else
-    s.add_development_dependency 'actionmailer', '~> 4.2.0'
-    s.add_development_dependency 'activesupport', '~> 4.2.0'
+    s.add_development_dependency 'actionmailer', '~> 4.2'
+    s.add_development_dependency 'activesupport', '~> 4.2'
     s.add_development_dependency 'nokogiri', '~> 1.6.0'
   end
 


### PR DESCRIPTION
No need to lock to specific patch (or even minor) version if dependencies are following [semver](https://semver.org/) since only major versions (like 5.0) may introduce breaking changes to the public API.